### PR TITLE
Fix multiline things

### DIFF
--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -211,6 +211,38 @@ module.exports = {
       return !isCloserException( left );
     }
 
+    /**
+     * Get the matching opening paren (if any) for the closing paren
+     * at the given index
+     * @method getOpeningParen
+     * @param  {Array<Object>} tokens An array of all tokens
+     * @param  {Number}        index  Index of closing paren within tokens
+     * @return {Object|Null}
+     */
+
+    function getOpeningParen( tokens, index ) {
+      // matching opening paren
+      let opener = null;
+      // current paren depth
+      let depth = 1;
+
+      // find matching open paren
+      for ( let i = index - 1; i >= 0; --i ) {
+        const candidate = tokens[ i ];
+
+        depth += (
+          candidate.value === '(' ? -1 : candidate.value === ')' ? 1 : 0
+        );
+
+        if ( depth === 0 ) {
+          opener = candidate;
+          break;
+        }
+      }
+
+      return opener;
+    }
+
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
@@ -331,6 +363,15 @@ module.exports = {
           );
 
           if ( isCloseParenAndNotEmpty ) {
+            // grab the matching opening paren
+            const opener = getOpeningParen( tokens, i );
+
+            // do the contents of this set of parens span multiple lines?
+            const multiline = (
+              opener &&
+              opener.loc.start.line !== token.loc.end.line
+            );
+
             let nestedLevels = 0;
             for ( let j = i; j > 0; j-- ) {
               let tokenToCheck = tokens[ j ];
@@ -344,13 +385,30 @@ module.exports = {
                     break;
                   }
                 } else if ( nestedLevels ===  1 && encloserExceptions.includes( tokenToCheck.value ) ) {
-                  if ( !sourceCode.isSpaceBetweenTokens( prevToken, token ) ) {
+                  const hasSpace = sourceCode.isSpaceBetweenTokens(
+                    prevToken,
+                    token
+                  );
+
+                  if ( !hasSpace && !multiline ) {
                     context.report({
                       node,
                       loc: token.loc.start,
                       message: MISSING_SPACE_MESSAGE,
                       fix( fixer ) {
                         return fixer.insertTextBefore( token, ' ' );
+                      }
+                    });
+                  } else if ( hasSpace && multiline ) {
+                    context.report({
+                      node,
+                      loc: token.loc.start,
+                      message: REJECTED_SPACE_MESSAGE,
+                      fix( fixer ) {
+                        return fixer.removeRange([
+                          prevToken.range[ 1 ],
+                          token.range[ 0 ]
+                        ]);
                       }
                     });
                   }

--- a/tests/space-in-parens.js
+++ b/tests/space-in-parens.js
@@ -53,11 +53,15 @@ ruleTester.run('space-in-parens', rule, {
             options: ['always']
         },
 
-        // function multiline no closing space
+        // single function, multiline no closing space
         {
-            code: `[].forEach( function() {
+            code: `[].forEach( function() {\n});`,
+            options: ['always', { 'exceptions': [ '{}', '[]', 'empty' ] } ],
+        },
 
-            });`,
+        // callback function multiline no closing space
+        {
+            code: `[].forEach( {}, function() {\n});`,
             options: ['always', { 'exceptions': [ '{}', '[]', 'empty' ] } ],
         },
 
@@ -74,6 +78,16 @@ ruleTester.run('space-in-parens', rule, {
         // single object literal
         {
             code: "console.log({ y: 'z' });",
+            options: ['always', { 'exceptions': [ '{}', '[]', 'empty' ] }]
+        },
+        // single multiline object literal
+        {
+            code: "console.log({ a: 'b',\nc: 'd' });",
+            options: ['always', { 'exceptions': [ '{}', '[]', 'empty' ] }]
+        },
+        // multiline object literal as last param
+        {
+            code: "console.log( 123, { a: 'b',\nc: 'd' });",
             options: ['always', { 'exceptions': [ '{}', '[]', 'empty' ] }]
         }
     ],
@@ -114,6 +128,7 @@ ruleTester.run('space-in-parens', rule, {
         {
             code: "[].forEach(function() {} );",
             options: ['always'],
+            output: `[].forEach( function() {} );`,
             errors: [{
                 message: 'There must be a space inside this paren.',
                 type: 'Program'
@@ -122,10 +137,20 @@ ruleTester.run('space-in-parens', rule, {
 
         // function multiline no closing space
         {
-            code: `[].forEach( function() {
-
-            } );`,
+            code: `[].forEach( function() {\n} );`,
             options: ['always', { 'exceptions': [ '{}', '[]', 'empty' ] } ],
+            output: `[].forEach( function() {\n});`,
+            errors: [{
+                message: 'There should be no spaces inside this paren.',
+                type: 'Program'
+            }]
+        },
+
+        // callback function multiline no closing space
+        {
+            code: `[].forEach( 123, function() {\n} );`,
+            options: ['always', { 'exceptions': [ '{}', '[]', 'empty' ] } ],
+            output: `[].forEach( 123, function() {\n});`,
             errors: [{
                 message: 'There should be no spaces inside this paren.',
                 type: 'Program'
@@ -221,6 +246,28 @@ ruleTester.run('space-in-parens', rule, {
                 type: 'Program'
             }, {
                 message: 'There must be a space inside this paren.',
+                type: 'Program'
+            }]
+        },
+
+        // single multiline object literal
+        {
+            code: "console.log({ a: 'b',\nc: 'd' } );",
+            output: "console.log({ a: 'b',\nc: 'd' });",
+            options: ['always', { 'exceptions': [ '{}', '[]', 'empty' ] }],
+            errors: [{
+                message: 'There should be no spaces inside this paren.',
+                type: 'Program'
+            }]
+        },
+
+        // multiline object literal as last param
+        {
+            code: "console.log( 123, { a: 'b',\nc: 'd' } );",
+            output: "console.log( 123, { a: 'b',\nc: 'd' });",
+            options: ['always', { 'exceptions': [ '{}', '[]', 'empty' ] }],
+            errors: [{
+                message: 'There should be no spaces inside this paren.',
                 type: 'Program'
             }]
         }


### PR DESCRIPTION
Somewhere along the line, this thing started asking you to do weird/ugly things like

```js
someFunction( 123, ( err, result ) => {
  doStuff();
} ); // <- note the space here
```

and

```js
someFunction( 123, {
  foo: 'bar',
  baz: 'bop'
} ); // <- note the space here
```

These should be (and historically have been, until recently) style guide violations. 

Basically, we disallow spaces before a closing paren if the preceding character is `}` or `]` and the paren contents span multiple lines.