### PR TITLE
Add Rule for No Invisible Characters

### DIFF
--- a/lib/rules/no-invisible-characters.js
+++ b/lib/rules/no-invisible-characters.js
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview Disallows invisible characters.
+ */
+
+const isInvisible      = require('../unicode').isInvisible;
+const toEscapedUnicode = require('../unicode').toEscapedUnicode;
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+
+  meta: {
+    fixable: 'code'
+  },
+
+  create( context ) {
+    const sourceCode = context.getSourceCode();
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    function reportInvisibleCharacter( node, range, instead ) {
+      context.report({
+        node,
+        data: {
+          instead
+        },
+        loc: {
+          start: sourceCode.getLocFromIndex( range[ 0 ] ),
+          end: sourceCode.getLocFromIndex( range[ 1 ] )
+        },
+        message: 'Unexpected invisible character. Use {{instead}} instead.',
+        fix( fixer ) {
+          return fixer.replaceTextRange(
+            range,
+            instead
+          );
+        }
+      });
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+      Program: function checkInvisibleCharacter( node ) {
+        const text = sourceCode.getText( node );
+
+        let index = 0;
+        for ( const c of text ) {
+          const codePoint = c.codePointAt( 0 );
+          if ( isInvisible( codePoint ) ) {
+            const range   = [ index, index + c.length ];
+            const instead = toEscapedUnicode( codePoint );
+            reportInvisibleCharacter( node, range, instead );
+          }
+          index += c.length;
+        }
+      }
+    };
+  }
+
+};

--- a/lib/unicode.js
+++ b/lib/unicode.js
@@ -1,0 +1,22 @@
+const HANGUL_FILLER             = '\u3164'.codePointAt( 0 );
+const HANGUL_CHOSEONG_FILLER    = '\u115F'.codePointAt( 0 );
+const HANGUL_JUNGSEONG_FILLER   = '\u1160'.codePointAt( 0 );
+
+const invisibleCharacters = [
+  HANGUL_FILLER,
+  HANGUL_CHOSEONG_FILLER,
+  HANGUL_JUNGSEONG_FILLER
+];
+
+const isInvisible = ( codePoint ) => {
+  return invisibleCharacters.includes( codePoint );
+};
+
+const toEscapedUnicode = ( codePoint ) => {
+  return `\\u${ codePoint.toString( 16 ).toUpperCase() }`;
+};
+
+module.exports = {
+  isInvisible,
+  toEscapedUnicode
+};

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,3 +1,4 @@
 require('./computed-property-spacing'),
 require('./space-in-parens'),
 require('./aligned-requires');
+require('./no-invisible-characters');

--- a/tests/no-invisible-characters.js
+++ b/tests/no-invisible-characters.js
@@ -1,0 +1,56 @@
+const rule       = require('../lib/rules/no-invisible-characters');
+const RuleTester = require('eslint').RuleTester;
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+});
+
+const ruleTester = new RuleTester();
+ruleTester.run( 'no-invisible-characters', rule, {
+
+  valid: [
+    {
+      code: 'const t = x[ 0 ]',
+      options: [ 'always' ]
+    }
+  ],
+
+  invalid: [
+    {
+      // HANGUL FILLER
+      code: 'const ㅤ = x[ 0 ]',
+      output: 'const \\u3164 = x[ 0 ]',
+      options: [ 'always' ],
+      errors: [
+        {
+          message: 'Unexpected invisible character. Use \\u3164 instead.'
+        }
+      ]
+    },
+    {
+      // HANGUL CHOSEONG FILLER
+      code: 'const ᅟ = x[ 1 ]',
+      output: 'const \\u115F = x[ 1 ]',
+      options: [ 'always' ],
+      errors: [
+        {
+          message: 'Unexpected invisible character. Use \\u115F instead.'
+        }
+      ]
+    },
+    {
+      // HANGUL JUNGSEONG FILLER
+      code: 'const ᅠ = x[ 2 ]',
+      output: 'const \\u1160 = x[ 2 ]',
+      options: [ 'always' ],
+      errors: [
+        {
+          message: 'Unexpected invisible character. Use \\u1160 instead.'
+        }
+      ]
+    }
+  ]
+
+});


### PR DESCRIPTION
#### Context
Reference [Jira ticket](https://starry.atlassian.net/browse/CS-537).

#### Implementation
 Adds a new rule in `lib/rules` that disallows invisible characters in source code text that aren't already
illegal characters.

*Note*: This rule is based on [regexp/no-invisible-character](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-invisible-character.html). The difference being `regexp/no-invisible-character` only checks for invisible characters in regular expressions.