### PR TITLE
Adding custom rule for disallowing spaces in empty constructors

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
   rules: {
     'computed-property-spacing': rule('computed-property-spacing'),
     'space-in-parens': rule('space-in-parens'),
-    'aligned-requires': rule('aligned-requires')
+    'aligned-requires': rule('aligned-requires'),
+    'disallow-space-in-constructors': rule('disallow-space-in-constructors')
   }
 };

--- a/lib/rules/disallow-space-in-constructors.js
+++ b/lib/rules/disallow-space-in-constructors.js
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Rule to flag when using constructor without parentheses
+ * @author Ilya Volodin
+ * @copyright 2022 Saahil Kumar (Starry mods + refactor)
+ */
+
+
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require('../ast-utils');
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('../shared/types').Rule} */
+module.exports = {
+  meta: {
+    type: 'layout',
+    fixable: 'code',
+    messages: {
+      unnecessary:  'Unnecessary space in parens when ' +
+                    'invoking a constructor with no arguments.'
+    }
+  },
+
+  create( context ) {
+
+    const sourceCode = context.getSourceCode();
+
+    return {
+      NewExpression( node ) {
+        if ( node.arguments.length !== 0 ) {
+          return; // if there are arguments, there have to be parens
+        }
+
+        const lastToken         = sourceCode.getLastToken( node );
+        const beforeLastToken   = sourceCode.getTokenBefore( lastToken );
+        const hasLastParen      = lastToken &&
+                                astUtils.isClosingParenToken( lastToken );
+
+        // `hasParens` is true only if the new expression ends with
+        // its own parens, e.g., new new foo() does not end with its own parens
+        const hasParens         = hasLastParen &&
+                                astUtils.isOpeningParenToken(
+                                  beforeLastToken ) &&
+                                node.callee.range[ 1 ] < node.range[ 1 ];
+
+        const spaceBetweenParens    = hasParens &&
+                                    sourceCode.isSpaceBetweenTokens(
+                                      beforeLastToken,
+                                      lastToken );
+
+
+        if ( spaceBetweenParens ) {
+          context.report({
+            node,
+            messageId: 'unnecessary',
+            fix: fixer => [
+              fixer.removeRange([
+                beforeLastToken.range[ 1 ],
+                lastToken.range[ 0 ]
+              ])
+            ]
+          });
+        }
+
+
+      }
+    };
+  }
+};

--- a/tests/disallow-space-in-constructors.js
+++ b/tests/disallow-space-in-constructors.js
@@ -1,0 +1,81 @@
+const rule       = require('../lib/rules/disallow-space-in-constructors');
+const RuleTester = require('eslint').RuleTester;
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+});
+
+
+const ruleTester = new RuleTester();
+ruleTester.run( 'disallow-space-in-constructors', rule, {
+
+  valid: [
+    {
+      code: 'const p = new Person'
+    },
+    {
+      code: 'const p = new Person()'
+    },
+    {
+      code: 'const p = (new Person)'
+    },
+    {
+      code: 'const p = (new Person)()'
+    },
+    {
+      code: 'const p = new Person(\'Name\')'
+    },
+    {
+      code: 'const p = new Person(\'Name\', \'Age\')'
+    }
+  ],
+
+  invalid: [
+    {
+      code: 'const p = new Person( )',
+      output: 'const p = new Person()',
+      errors: [
+        {
+          message: 'Unnecessary space in parens ' +
+            'when invoking a constructor with no arguments.',
+          type: 'NewExpression'
+        }
+      ]
+    },
+    {
+      code: 'const p = new Person(        )',
+      output: 'const p = new Person()',
+      errors: [
+        {
+          message: 'Unnecessary space in parens ' +
+              'when invoking a constructor with no arguments.',
+          type: 'NewExpression'
+        }
+      ]
+    },
+    {
+      code: 'const p = new (Person)( )',
+      output: 'const p = new (Person)()',
+      errors: [
+        {
+          message: 'Unnecessary space in parens ' +
+                'when invoking a constructor with no arguments.',
+          type: 'NewExpression'
+        }
+      ]
+    },
+    {
+      code: 'const p = new (Person)(        )',
+      output: 'const p = new (Person)()',
+      errors: [
+        {
+          message: 'Unnecessary space in parens ' +
+                  'when invoking a constructor with no arguments.',
+          type: 'NewExpression'
+        }
+      ]
+    }
+  ]
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,3 +1,4 @@
 require('./computed-property-spacing'),
 require('./space-in-parens'),
-require('./aligned-requires');
+require('./aligned-requires'),
+require('./disallow-space-in-constructors');


### PR DESCRIPTION
### Context
Jira Ticket: [CS-425](https://starry.atlassian.net/browse/CS-425)

This custom rule makes it so that you cannot put spaces in a constructor that has no arguments.

Examples of valid constructors:
- `new Person`
- `new Person()`
- `(new Person)`
- `(new Person)()`
- `new Person('name')`

Examples of invalid constructors:
- `new Person( )`
- `new (Person)( )`


### Implementation
I took the existing [new-parens](https://eslint.org/docs/rules/new-parens) rule and modified it to essentially always use the `"never"` behavior but still allow the use of empty parentheses.